### PR TITLE
feat: support mps fallback

### DIFF
--- a/Diffusion/Diffusion.py
+++ b/Diffusion/Diffusion.py
@@ -23,8 +23,9 @@ class GaussianDiffusionTrainer(nn.Module):
         self.model = model
         self.T = T
 
+        dtype = torch.float32 if torch.backends.mps.is_available() else torch.float64
         self.register_buffer(
-            'betas', torch.linspace(beta_1, beta_T, T).double())
+            'betas', torch.linspace(beta_1, beta_T, T, dtype=dtype))
         alphas = 1. - self.betas
         alphas_bar = torch.cumprod(alphas, dim=0)
 
@@ -54,7 +55,8 @@ class GaussianDiffusionSampler(nn.Module):
         self.model = model
         self.T = T
 
-        self.register_buffer('betas', torch.linspace(beta_1, beta_T, T).double())
+        dtype = torch.float32 if torch.backends.mps.is_available() else torch.float64
+        self.register_buffer('betas', torch.linspace(beta_1, beta_T, T, dtype=dtype))
         alphas = 1. - self.betas
         alphas_bar = torch.cumprod(alphas, dim=0)
         alphas_bar_prev = F.pad(alphas_bar, [1, 0], value=1)[:T]

--- a/MainCondition.py
+++ b/MainCondition.py
@@ -1,5 +1,5 @@
 from DiffusionFreeGuidence.TrainCondition import train, eval
-
+import torch
 
 def main(model_config=None):
     modelConfig = {
@@ -29,6 +29,20 @@ def main(model_config=None):
     }
     if model_config is not None:
         modelConfig = model_config
+
+    # 动态选择设备：优先使用 CUDA，其次是 Apple MPS，最后回退到 CPU
+    if torch.cuda.is_available():
+        modelConfig["device"] = "cuda:0"
+    elif torch.backends.mps.is_available():
+        modelConfig["device"] = "mps"
+    else:
+        modelConfig["device"] = "cpu"
+
+    print(f"Using device: {modelConfig['device']}")
+
+    # 强制使用 float32，确保在 MPS 上运行
+    modelConfig["dtype"] = torch.float32
+
     if modelConfig["state"] == "train":
         train(modelConfig)
     else:


### PR DESCRIPTION
## Summary
- use MPS when CUDA is unavailable in conditional training script
- avoid float64 tensors on MPS by selecting float32 for diffusion buffers

## Testing
- `python -m py_compile Main.py MainCondition.py Diffusion/Diffusion.py Diffusion/Train.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaf6ba45e88323b540afc1c94aa6fd