### PR TITLE
feat: support mps fallback

### DIFF
--- a/Diffusion/Diffusion.py
+++ b/Diffusion/Diffusion.py
@@ -13,7 +13,7 @@ def extract(v, t, x_shape):
     """
     device = t.device
     out = torch.gather(v, index=t, dim=0).float().to(device)
-    return out.view([t.shape[0]] + [1] * (len(x_shape) - 1))
+    return out.reshape([t.shape[0]] + [1] * (len(x_shape) - 1))
 
 
 class GaussianDiffusionTrainer(nn.Module):
@@ -23,8 +23,9 @@ class GaussianDiffusionTrainer(nn.Module):
         self.model = model
         self.T = T
 
+        dtype = torch.float32 if torch.backends.mps.is_available() else torch.float64
         self.register_buffer(
-            'betas', torch.linspace(beta_1, beta_T, T).double())
+            'betas', torch.linspace(beta_1, beta_T, T, dtype=dtype))
         alphas = 1. - self.betas
         alphas_bar = torch.cumprod(alphas, dim=0)
 
@@ -54,7 +55,8 @@ class GaussianDiffusionSampler(nn.Module):
         self.model = model
         self.T = T
 
-        self.register_buffer('betas', torch.linspace(beta_1, beta_T, T).double())
+        dtype = torch.float32 if torch.backends.mps.is_available() else torch.float64
+        self.register_buffer('betas', torch.linspace(beta_1, beta_T, T, dtype=dtype))
         alphas = 1. - self.betas
         alphas_bar = torch.cumprod(alphas, dim=0)
         alphas_bar_prev = F.pad(alphas_bar, [1, 0], value=1)[:T]

--- a/Diffusion/Model.py
+++ b/Diffusion/Model.py
@@ -23,7 +23,7 @@ class TimeEmbedding(nn.Module):
         assert list(emb.shape) == [T, d_model // 2]
         emb = torch.stack([torch.sin(emb), torch.cos(emb)], dim=-1)
         assert list(emb.shape) == [T, d_model // 2, 2]
-        emb = emb.view(T, d_model)
+        emb = emb.reshape(T, d_model)
 
         self.timembedding = nn.Sequential(
             nn.Embedding.from_pretrained(emb),
@@ -100,16 +100,16 @@ class AttnBlock(nn.Module):
         k = self.proj_k(h)
         v = self.proj_v(h)
 
-        q = q.permute(0, 2, 3, 1).view(B, H * W, C)
-        k = k.view(B, C, H * W)
+        q = q.permute(0, 2, 3, 1).reshape(B, H * W, C)
+        k = k.reshape(B, C, H * W)
         w = torch.bmm(q, k) * (int(C) ** (-0.5))
         assert list(w.shape) == [B, H * W, H * W]
         w = F.softmax(w, dim=-1)
 
-        v = v.permute(0, 2, 3, 1).view(B, H * W, C)
+        v = v.permute(0, 2, 3, 1).reshape(B, H * W, C)
         h = torch.bmm(w, v)
         assert list(h.shape) == [B, H * W, C]
-        h = h.view(B, H, W, C).permute(0, 3, 1, 2)
+        h = h.reshape(B, H, W, C).permute(0, 3, 1, 2)
         h = self.proj(h)
 
         return x + h

--- a/DiffusionFreeGuidence/DiffusionCondition.py
+++ b/DiffusionFreeGuidence/DiffusionCondition.py
@@ -13,7 +13,7 @@ def extract(v, t, x_shape):
     """
     device = t.device
     out = torch.gather(v, index=t, dim=0).float().to(device)
-    return out.view([t.shape[0]] + [1] * (len(x_shape) - 1))
+    return out.reshape([t.shape[0]] + [1] * (len(x_shape) - 1))
 
 
 class GaussianDiffusionTrainer(nn.Module):
@@ -23,8 +23,9 @@ class GaussianDiffusionTrainer(nn.Module):
         self.model = model
         self.T = T
 
+        dtype = torch.float32 if torch.backends.mps.is_available() else torch.float64
         self.register_buffer(
-            'betas', torch.linspace(beta_1, beta_T, T).double())
+            'betas', torch.linspace(beta_1, beta_T, T, dtype=dtype))
         alphas = 1. - self.betas
         alphas_bar = torch.cumprod(alphas, dim=0)
 
@@ -57,7 +58,8 @@ class GaussianDiffusionSampler(nn.Module):
         ### w > 0 and label > 0 means guidence. Guidence would be stronger if w is bigger.
         self.w = w
 
-        self.register_buffer('betas', torch.linspace(beta_1, beta_T, T).double())
+        dtype = torch.float32 if torch.backends.mps.is_available() else torch.float64
+        self.register_buffer('betas', torch.linspace(beta_1, beta_T, T, dtype=dtype))
         alphas = 1. - self.betas
         alphas_bar = torch.cumprod(alphas, dim=0)
         alphas_bar_prev = F.pad(alphas_bar, [1, 0], value=1)[:T]

--- a/DiffusionFreeGuidence/ModelCondition.py
+++ b/DiffusionFreeGuidence/ModelCondition.py
@@ -32,7 +32,7 @@ class TimeEmbedding(nn.Module):
         assert list(emb.shape) == [T, d_model // 2]
         emb = torch.stack([torch.sin(emb), torch.cos(emb)], dim=-1)
         assert list(emb.shape) == [T, d_model // 2, 2]
-        emb = emb.view(T, d_model)
+        emb = emb.reshape(T, d_model)
 
         self.timembedding = nn.Sequential(
             nn.Embedding.from_pretrained(emb, freeze=False),
@@ -102,16 +102,16 @@ class AttnBlock(nn.Module):
         k = self.proj_k(h)
         v = self.proj_v(h)
 
-        q = q.permute(0, 2, 3, 1).view(B, H * W, C)
-        k = k.view(B, C, H * W)
+        q = q.permute(0, 2, 3, 1).reshape(B, H * W, C)
+        k = k.reshape(B, C, H * W)
         w = torch.bmm(q, k) * (int(C) ** (-0.5))
         assert list(w.shape) == [B, H * W, H * W]
         w = F.softmax(w, dim=-1)
 
-        v = v.permute(0, 2, 3, 1).view(B, H * W, C)
+        v = v.permute(0, 2, 3, 1).reshape(B, H * W, C)
         h = torch.bmm(w, v)
         assert list(h.shape) == [B, H * W, C]
-        h = h.view(B, H, W, C).permute(0, 3, 1, 2)
+        h = h.reshape(B, H, W, C).permute(0, 3, 1, 2)
         h = self.proj(h)
 
         return x + h

--- a/MainCondition.py
+++ b/MainCondition.py
@@ -1,5 +1,5 @@
 from DiffusionFreeGuidence.TrainCondition import train, eval
-
+import torch
 
 def main(model_config=None):
     modelConfig = {
@@ -29,6 +29,20 @@ def main(model_config=None):
     }
     if model_config is not None:
         modelConfig = model_config
+
+    # 动态选择设备：优先使用 CUDA，其次是 Apple MPS，最后回退到 CPU
+    if torch.cuda.is_available():
+        modelConfig["device"] = "cuda:0"
+    elif torch.backends.mps.is_available():
+        modelConfig["device"] = "mps"
+    else:
+        modelConfig["device"] = "cpu"
+
+    print(f"Using device: {modelConfig['device']}")
+
+    # 强制使用 float32，确保在 MPS 上运行
+    modelConfig["dtype"] = torch.float32
+
     if modelConfig["state"] == "train":
         train(modelConfig)
     else:


### PR DESCRIPTION
## Summary
- use MPS when CUDA is unavailable in conditional training script
- avoid float64 tensors on MPS by selecting float32 for diffusion buffers
- replace tensor `.view` calls with `.reshape` to handle non-contiguous MPS tensors

## Testing
- `python -m py_compile Main.py MainCondition.py Diffusion/Diffusion.py Diffusion/Model.py Diffusion/Train.py DiffusionFreeGuidence/DiffusionCondition.py DiffusionFreeGuidence/ModelCondition.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaf6ba45e88323b540afc1c94aa6fd