### PR TITLE
Ensure training images are contiguous

### DIFF
--- a/Diffusion/Train.py
+++ b/Diffusion/Train.py
@@ -49,7 +49,12 @@ def train(modelConfig: Dict):
             for images, labels in tqdmDataLoader:
                 # train
                 optimizer.zero_grad()
-                x_0 = images.to(device)
+                # ``RandomHorizontalFlip`` from torchvision may return tensors with
+                # negative strides, which can later trigger ``view``-related
+                # errors inside PyTorch's autograd when backpropagating.  Making
+                # the tensor contiguous here ensures a standard memory layout
+                # before it is used in the diffusion model.
+                x_0 = images.to(device).contiguous()
                 loss = trainer(x_0).sum() / 1000.
                 loss.backward()
                 torch.nn.utils.clip_grad_norm_(


### PR DESCRIPTION
## Summary
- make CIFAR-10 batches contiguous before computing diffusion loss to avoid view-related autograd errors

## Testing
- `python -m py_compile Diffusion/Train.py`
- ⚠️ `pip install torch torchvision` (failed: Could not find a version that satisfies the requirement torch)

------
https://chatgpt.com/codex/tasks/task_e_68ab019936388323aec3913482fd22f0