### PR TITLE
Handle negative-stride image tensors in conditional training

### DIFF
--- a/DiffusionFreeGuidence/TrainCondition.py
+++ b/DiffusionFreeGuidence/TrainCondition.py
@@ -52,7 +52,11 @@ def train(modelConfig: Dict):
                 # train
                 b = images.shape[0]
                 optimizer.zero_grad()
-                x_0 = images.to(device)
+                # ``RandomHorizontalFlip`` can produce tensors with negative strides when
+                # used in other settings. Calling ``contiguous`` here ensures a standard
+                # memory layout before further processing and avoids view-related errors
+                # in autograd for any such tensors.
+                x_0 = images.to(device).contiguous()
                 labels = labels.to(device) + 1
                 if np.random.rand() < 0.1:
                     labels = torch.zeros_like(labels).to(device)


### PR DESCRIPTION
## Summary
- Guard against non-contiguous tensors caused by data augmentation by calling `.contiguous()` on training images in conditional training.
- Document reason for this with inline comments.

## Testing
- `python -m py_compile DiffusionFreeGuidence/TrainCondition.py Diffusion/Train.py`
- `python -m py_compile Main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab071584508323b28bca4d98d11bc3