### PR TITLE
Handle negative-stride tensors before device transfer

### DIFF
--- a/Diffusion/Train.py
+++ b/Diffusion/Train.py
@@ -54,7 +54,7 @@ def train(modelConfig: Dict):
                 # errors inside PyTorch's autograd when backpropagating.  Making
                 # the tensor contiguous here ensures a standard memory layout
                 # before it is used in the diffusion model.
-                x_0 = images.to(device).contiguous()
+                x_0 = images.contiguous().to(device)
                 loss = trainer(x_0).sum() / 1000.
                 loss.backward()
                 torch.nn.utils.clip_grad_norm_(

--- a/DiffusionFreeGuidence/TrainCondition.py
+++ b/DiffusionFreeGuidence/TrainCondition.py
@@ -56,7 +56,7 @@ def train(modelConfig: Dict):
                 # used in other settings. Calling ``contiguous`` here ensures a standard
                 # memory layout before further processing and avoids view-related errors
                 # in autograd for any such tensors.
-                x_0 = images.to(device).contiguous()
+                x_0 = images.contiguous().to(device)
                 labels = labels.to(device) + 1
                 if np.random.rand() < 0.1:
                     labels = torch.zeros_like(labels).to(device)


### PR DESCRIPTION
## Summary
- Ensure training images are made contiguous before moving to the target device in both training scripts
- Avoid potential `view` errors caused by negative-stride tensors from `RandomHorizontalFlip`

## Testing
- `python -m py_compile Diffusion/Train.py DiffusionFreeGuidence/TrainCondition.py`
- `pip install torch==2.2.0 torchvision==0.17.0 --index-url https://download.pytorch.org/whl/cpu` *(failed: Could not connect to proxy / no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0b0dea748323b2a3cc2ba47c6650